### PR TITLE
AArch64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BASE_IMAGE_TAG = latest
 BUILD_IMAGE_TAG = v1
 
 all:
-	env GOOS=linux GOARCH=amd64 go build -ldflags='-s -w' -buildvcs=false .
+	go build -ldflags='-s -w' -buildvcs=false .
 
 binary:
 	@echo "Making $@ ..."


### PR DESCRIPTION
Hello,
This series enables AArch64 support in Neuvector.

Removing Amd64 build flags to enable multi-arch compilation.

Note that we are pushing a few pull requests to different Neuvector repos. For testing purposes, all these should be considered together.
Cheers, Dean