### PR TITLE
NVSHAS-9278: update docker dependency to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/digitorus/timestamp v0.0.0-20231217203849-220c5c2851b7 // indirect
 	github.com/docker/cli v24.0.7+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
-	github.com/docker/docker v26.1.4+incompatible // indirect
+	github.com/docker/docker v27.1.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/docker/cli v24.0.7+incompatible h1:wa/nIwYFW7BVTGa7SWPVyyXU9lgORqUb1x
 github.com/docker/cli v24.0.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v26.1.4+incompatible h1:vuTpXDuoga+Z38m1OZHzl7NKisKWaWlhjQk7IDPSLsU=
-github.com/docker/docker v26.1.4+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.1.2+incompatible h1:AhGzR1xaQIy53qCkxARaFluI00WPGtXn0AJuoQsVYTY=
+github.com/docker/docker v27.1.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.0 h1:YQFtbBQb4VrpoPxhFuzEBPQ9E16qz5SpHLS+uswaCp8=
 github.com/docker/docker-credential-helpers v0.8.0/go.mod h1:UGFXcuoQ5TxPiB54nHOZ32AWRqQdECoh/Mg0AlEYb40=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/vendor/github.com/docker/docker/AUTHORS
+++ b/vendor/github.com/docker/docker/AUTHORS
@@ -10,6 +10,7 @@ Aaron Huslage <huslage@gmail.com>
 Aaron L. Xu <liker.xu@foxmail.com>
 Aaron Lehmann <alehmann@netflix.com>
 Aaron Welch <welch@packet.net>
+Aaron Yoshitake <airandfingers@gmail.com>
 Abel Muiño <amuino@gmail.com>
 Abhijeet Kasurde <akasurde@redhat.com>
 Abhinandan Prativadi <aprativadi@gmail.com>
@@ -62,6 +63,7 @@ alambike <alambike@gmail.com>
 Alan Hoyle <alan@alanhoyle.com>
 Alan Scherger <flyinprogrammer@gmail.com>
 Alan Thompson <cloojure@gmail.com>
+Alano Terblanche <alano.terblanche@docker.com>
 Albert Callarisa <shark234@gmail.com>
 Albert Zhang <zhgwenming@gmail.com>
 Albin Kerouanton <albinker@gmail.com>
@@ -141,6 +143,7 @@ Andreas Tiefenthaler <at@an-ti.eu>
 Andrei Gherzan <andrei@resin.io>
 Andrei Ushakov <aushakov@netflix.com>
 Andrei Vagin <avagin@gmail.com>
+Andrew Baxter <423qpsxzhh8k3h@s.rendaw.me>
 Andrew C. Bodine <acbodine@us.ibm.com>
 Andrew Clay Shafer <andrewcshafer@gmail.com>
 Andrew Duckworth <grillopress@gmail.com>
@@ -193,6 +196,7 @@ Anton Löfgren <anton.lofgren@gmail.com>
 Anton Nikitin <anton.k.nikitin@gmail.com>
 Anton Polonskiy <anton.polonskiy@gmail.com>
 Anton Tiurin <noxiouz@yandex.ru>
+Antonio Aguilar <antonio@zoftko.com>
 Antonio Murdaca <antonio.murdaca@gmail.com>
 Antonis Kalipetis <akalipetis@gmail.com>
 Antony Messerli <amesserl@rackspace.com>
@@ -221,7 +225,6 @@ Avi Das <andas222@gmail.com>
 Avi Kivity <avi@scylladb.com>
 Avi Miller <avi.miller@oracle.com>
 Avi Vaid <avaid1996@gmail.com>
-ayoshitake <airandfingers@gmail.com>
 Azat Khuyiyakhmetov <shadow_uz@mail.ru>
 Bao Yonglei <baoyonglei@huawei.com>
 Bardia Keyoumarsi <bkeyouma@ucsc.edu>
@@ -316,6 +319,7 @@ Burke Libbey <burke@libbey.me>
 Byung Kang <byung.kang.ctr@amrdec.army.mil>
 Caleb Spare <cespare@gmail.com>
 Calen Pennington <cale@edx.org>
+Calvin Liu <flycalvin@qq.com>
 Cameron Boehmer <cameron.boehmer@gmail.com>
 Cameron Sparr <gh@sparr.email>
 Cameron Spear <cameronspear@gmail.com>
@@ -362,6 +366,7 @@ Chen Qiu <cheney-90@hotmail.com>
 Cheng-mean Liu <soccerl@microsoft.com>
 Chengfei Shang <cfshang@alauda.io>
 Chengguang Xu <cgxu519@gmx.com>
+Chentianze <cmoman@126.com>
 Chenyang Yan <memory.yancy@gmail.com>
 chenyuzhu <chenyuzhi@oschina.cn>
 Chetan Birajdar <birajdar.chetan@gmail.com>
@@ -409,6 +414,7 @@ Christopher Crone <christopher.crone@docker.com>
 Christopher Currie <codemonkey+github@gmail.com>
 Christopher Jones <tophj@linux.vnet.ibm.com>
 Christopher Latham <sudosurootdev@gmail.com>
+Christopher Petito <chrisjpetito@gmail.com>
 Christopher Rigor <crigor@gmail.com>
 Christy Norman <christy@linux.vnet.ibm.com>
 Chun Chen <ramichen@tencent.com>
@@ -777,6 +783,7 @@ Gabriel L. Somlo <gsomlo@gmail.com>
 Gabriel Linder <linder.gabriel@gmail.com>
 Gabriel Monroy <gabriel@opdemand.com>
 Gabriel Nicolas Avellaneda <avellaneda.gabriel@gmail.com>
+Gabriel Tomitsuka <gabriel@tomitsuka.com>
 Gaetan de Villele <gdevillele@gmail.com>
 Galen Sampson <galen.sampson@gmail.com>
 Gang Qiao <qiaohai8866@gmail.com>
@@ -792,6 +799,7 @@ Geoff Levand <geoff@infradead.org>
 Geoffrey Bachelet <grosfrais@gmail.com>
 Geon Kim <geon0250@gmail.com>
 George Kontridze <george@bugsnag.com>
+George Ma <mayangang@outlook.com>
 George MacRorie <gmacr31@gmail.com>
 George Xie <georgexsh@gmail.com>
 Georgi Hristozov <georgi@forkbomb.nl>
@@ -913,6 +921,7 @@ Illo Abdulrahim <abdulrahim.illo@nokia.com>
 Ilya Dmitrichenko <errordeveloper@gmail.com>
 Ilya Gusev <mail@igusev.ru>
 Ilya Khlopotov <ilya.khlopotov@gmail.com>
+imalasong <2879499479@qq.com>
 imre Fitos <imre.fitos+github@gmail.com>
 inglesp <peter.inglesby@gmail.com>
 Ingo Gottwald <in.gottwald@gmail.com>
@@ -930,6 +939,7 @@ J Bruni <joaohbruni@yahoo.com.br>
 J. Nunn <jbnunn@gmail.com>
 Jack Danger Canty <jackdanger@squareup.com>
 Jack Laxson <jackjrabbit@gmail.com>
+Jack Walker <90711509+j2walker@users.noreply.github.com>
 Jacob Atzen <jacob@jacobatzen.dk>
 Jacob Edelman <edelman.jd@gmail.com>
 Jacob Tomlinson <jacob@tom.linson.uk>
@@ -989,6 +999,7 @@ Jason Shepherd <jason@jasonshepherd.net>
 Jason Smith <jasonrichardsmith@gmail.com>
 Jason Sommer <jsdirv@gmail.com>
 Jason Stangroome <jason@codeassassin.com>
+Jasper Siepkes <siepkes@serviceplanet.nl>
 Javier Bassi <javierbassi@gmail.com>
 jaxgeller <jacksongeller@gmail.com>
 Jay <teguhwpurwanto@gmail.com>
@@ -1100,6 +1111,7 @@ Jon Johnson <jonjohnson@google.com>
 Jon Surrell <jon.surrell@gmail.com>
 Jon Wedaman <jweede@gmail.com>
 Jonas Dohse <jonas@dohse.ch>
+Jonas Geiler <git@jonasgeiler.com>
 Jonas Heinrich <Jonas@JonasHeinrich.com>
 Jonas Pfenniger <jonas@pfenniger.name>
 Jonathan A. Schweder <jonathanschweder@gmail.com>
@@ -1267,6 +1279,7 @@ Lakshan Perera <lakshan@laktek.com>
 Lalatendu Mohanty <lmohanty@redhat.com>
 Lance Chen <cyen0312@gmail.com>
 Lance Kinley <lkinley@loyaltymethods.com>
+Lars Andringa <l.s.andringa@rug.nl>
 Lars Butler <Lars.Butler@gmail.com>
 Lars Kellogg-Stedman <lars@redhat.com>
 Lars R. Damerow <lars@pixar.com>
@@ -1673,6 +1686,7 @@ Patrick Böänziger <patrick.baenziger@bsi-software.com>
 Patrick Devine <patrick.devine@docker.com>
 Patrick Haas <patrickhaas@google.com>
 Patrick Hemmer <patrick.hemmer@gmail.com>
+Patrick St. laurent <patrick@saint-laurent.us>
 Patrick Stapleton <github@gdi2290.com>
 Patrik Cyvoct <patrik@ptrk.io>
 pattichen <craftsbear@gmail.com>
@@ -1878,6 +1892,7 @@ Royce Remer <royceremer@gmail.com>
 Rozhnov Alexandr <nox73@ya.ru>
 Rudolph Gottesheim <r.gottesheim@loot.at>
 Rui Cao <ruicao@alauda.io>
+Rui JingAn <quiterace@gmail.com>
 Rui Lopes <rgl@ruilopes.com>
 Ruilin Li <liruilin4@huawei.com>
 Runshen Zhu <runshen.zhu@gmail.com>
@@ -2184,6 +2199,7 @@ Tomek Mańko <tomek.manko@railgun-solutions.com>
 Tommaso Visconti <tommaso.visconti@gmail.com>
 Tomoya Tabuchi <t@tomoyat1.com>
 Tomáš Hrčka <thrcka@redhat.com>
+Tomáš Virtus <nechtom@gmail.com>
 tonic <tonicbupt@gmail.com>
 Tonny Xu <tonny.xu@gmail.com>
 Tony Abboud <tdabboud@hotmail.com>
@@ -2228,6 +2244,7 @@ Victor I. Wood <viw@t2am.com>
 Victor Lyuboslavsky <victor@victoreda.com>
 Victor Marmol <vmarmol@google.com>
 Victor Palma <palma.victor@gmail.com>
+Victor Toni <victor.toni@gmail.com>
 Victor Vieux <victor.vieux@docker.com>
 Victoria Bialas <victoria.bialas@docker.com>
 Vijaya Kumar K <vijayak@caviumnetworks.com>
@@ -2279,6 +2296,7 @@ Wassim Dhif <wassimdhif@gmail.com>
 Wataru Ishida <ishida.wataru@lab.ntt.co.jp>
 Wayne Chang <wayne@neverfear.org>
 Wayne Song <wsong@docker.com>
+weebney <weebney@gmail.com>
 Weerasak Chongnguluam <singpor@gmail.com>
 Wei Fu <fuweid89@gmail.com>
 Wei Wu <wuwei4455@gmail.com>

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -66,7 +66,7 @@ github.com/docker/cli/cli/config/types
 # github.com/docker/distribution v2.8.3+incompatible
 ## explicit
 github.com/docker/distribution/registry/client/auth/challenge
-# github.com/docker/docker v26.1.4+incompatible
+# github.com/docker/docker v27.1.2+incompatible
 ## explicit
 github.com/docker/docker/pkg/homedir
 # github.com/docker/docker-credential-helpers v0.8.0


### PR DESCRIPTION
The docker package v26.1.4 is flagged with a critical severity CVE, updating the dependency to v27.1.2 will fix the issue.