### PR TITLE
chore: bump version for cve

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/neuvector/sigstore-interface
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/google/go-containerregistry v0.21.3
@@ -66,7 +66,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/in-toto/attestation v1.1.2 // indirect
-	github.com/in-toto/in-toto-golang v0.10.0 // indirect
+	github.com/in-toto/in-toto-golang v0.11.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/in-toto/attestation v1.1.2 h1:MBFn6lsMq6dptQZJBhalXTcWMb/aJy3V+GX3VYj/V1E=
 github.com/in-toto/attestation v1.1.2/go.mod h1:gYFddHMZj3DiQ0b62ltNi1Vj5rC879bTmBbrv9CRHpM=
-github.com/in-toto/in-toto-golang v0.10.0 h1:+s2eZQSK3WmWfYV85qXVSBfqgawi/5L02MaqA4o/tpM=
-github.com/in-toto/in-toto-golang v0.10.0/go.mod h1:wjT4RiyFlLWCmLUJjwB8oZcjaq7HA390aMJcD3xXgmg=
+github.com/in-toto/in-toto-golang v0.11.0 h1:nfidMYBFx+E0lnmX5KUnN2Pdm8zdNKal1ayjJuzzRoA=
+github.com/in-toto/in-toto-golang v0.11.0/go.mod h1:u3PjTnwFKjp5a1YCcw8SJg0G+tMeKfVoWsWeFMDCMtw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/vendor/github.com/in-toto/in-toto-golang/in_toto/match.go
+++ b/vendor/github.com/in-toto/in-toto-golang/in_toto/match.go
@@ -22,8 +22,12 @@ var errBadPattern = errors.New("syntax error in pattern")
 //	term:
 //		'*'         matches any sequence of non-/ characters
 //		'?'         matches any single non-/ character
-//		'[' [ '^' ] { character-range } ']'
+//		'[' [ '!' ] { character-range } ']'
 //		            character class (must be non-empty)
+//
+// NOTE: Only '!' is supported for character class negation, not '^'. This is to
+// ensure compatibility with in-toto-python.
+//
 //		c           matches character c (c != '*', '?', '\\', '[')
 //		'\\' c      matches character c
 //
@@ -141,7 +145,7 @@ func matchChunk(chunk, s string) (rest string, ok bool, err error) {
 			chunk = chunk[1:]
 			// possibly negated
 			negated := false
-			if len(chunk) > 0 && chunk[0] == '^' {
+			if len(chunk) > 0 && chunk[0] == '!' {
 				negated = true
 				chunk = chunk[1:]
 			}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -239,7 +239,7 @@ github.com/hashicorp/go-retryablehttp
 github.com/in-toto/attestation/go/predicates/provenance/v02
 github.com/in-toto/attestation/go/predicates/provenance/v1
 github.com/in-toto/attestation/go/v1
-# github.com/in-toto/in-toto-golang v0.10.0
+# github.com/in-toto/in-toto-golang v0.11.0
 ## explicit; go 1.24.0
 github.com/in-toto/in-toto-golang/in_toto
 github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common


### PR DESCRIPTION
- go version 1.26.3